### PR TITLE
ignoring created inputs, outputs, and vscode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Compiled python modules
 *.pyc
 
+# VSCode folders
+/.vscode
+
 # PyCharm folders
 /.idea
 /.cache
@@ -18,3 +21,9 @@
 
 # Output folder
 /outputs/
+
+# All new files coming out of buildInputs
+inputs/example_inputs/*/optional_inputs.json
+inputs/example_inputs/*/optional_inputs.py
+inputs/example_inputs/*/simulated_inputs.json
+inputs/example_inputs/*/build_input.py


### PR DESCRIPTION
@zsarnoczay @dustin-cook @faraz-zaidi 

Updating .gitignore file to not track any additional `build_input.py` , `optional_input.py`, or their outputs in the repo.