### PR TITLE
Add option for Numpy seed

### DIFF
--- a/driver_PBEE_recovery.py
+++ b/driver_PBEE_recovery.py
@@ -19,7 +19,9 @@ def run_analysis(model_name, seed=None):
         Name of the model. Inputs are expected to be in a directory with this 
         name. Outputs will save to a directory with this name
     
-    
+    seed: int
+        Random seed to be passed to the Numpy random engine. Default behavior
+        is set as None and will not pass a random seed.
     """'''
     
     import time


### PR DESCRIPTION
Added keyword argument in `driver_PBEE_recovery.py` to allow for a Numpy seed to be set. Default behavior is set to "None", which does not pass in a seed at all.

Seed should propagate through all subfunctions, so if a subfunction requires a distinct random variate, a seed instance will have to be used instead.