### PR TITLE
Fix: Fire suppression keycheck and custom output name

### DIFF
--- a/src/atc138/cli.py
+++ b/src/atc138/cli.py
@@ -7,6 +7,7 @@ def main():
     parser = argparse.ArgumentParser(description="Run ATC-138 Functional Recovery Assessment")
     parser.add_argument("input_dir", help="Path to the directory containing input files (e.g., simulated_inputs.json)")
     parser.add_argument("output_dir", help="Path to the directory where outputs will be saved")
+    parser.add_argument("--output_file", type=str, help="String to name output file (default recovery_outputs.json)", default="recovery_outputs.json")
     parser.add_argument("--seed", type=int, help="Random seed for reproducibility", default=None)
     parser.add_argument("--force_rebuild", action="store_true", help="Flag to force override of simulated_inputs.json and rebuild", default=False)
 
@@ -18,7 +19,7 @@ def main():
         sys.exit(1)
 
     try:
-        run_analysis(args.input_dir, args.output_dir, seed=args.seed, force_rebuild=args.force_rebuild)
+        run_analysis(args.input_dir, args.output_dir, output_file=args.output_file, seed=args.seed, force_rebuild=args.force_rebuild)
     except Exception as e:
         print(f"Error running analysis: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/atc138/driver.py
+++ b/src/atc138/driver.py
@@ -1,5 +1,5 @@
 def run_analysis(input_dir, output_dir, 
-                 output_file=None,
+                 output_file='recovery_outputs.json',
                  seed=None, force_rebuild=False):
 
     '''This script facilitates the performance based functional recovery and
@@ -24,8 +24,7 @@ def run_analysis(input_dir, output_dir,
         Path to the directory where the output file (recovery_outputs.json) will be saved.
         
     output_file: string
-        If None (default), output file (recovery_outputs.json) will be saved. If string, name the 
-        output file as specified.
+        Name the output file as specified. Default name is 'recovery_outputs.json'. 
     
     seed: int
         Random seed to be passed to the Numpy random engine. Default behavior
@@ -196,9 +195,6 @@ def run_analysis(input_dir, output_dir,
                                             fnc_keys_6 = list(functionality[k_1][k_2][k_3][k_4][k_5].keys())
     
     output_json_object = json.dumps(functionality)
-
-    if output_file is None:
-        output_file = "recovery_outputs.json"
     
     with open(os.path.join(output_dir, output_file), "w") as outfile:
         outfile.write(output_json_object)

--- a/src/atc138/driver.py
+++ b/src/atc138/driver.py
@@ -1,4 +1,6 @@
-def run_analysis(input_dir, output_dir, seed=None, force_rebuild=False):
+def run_analysis(input_dir, output_dir, 
+                 output_file=None,
+                 seed=None, force_rebuild=False):
 
     '''This script facilitates the performance based functional recovery and
     reoccupancy assessment of a single building for a single intensity level
@@ -20,6 +22,10 @@ def run_analysis(input_dir, output_dir, seed=None, force_rebuild=False):
     
     output_dir: string
         Path to the directory where the output file (recovery_outputs.json) will be saved.
+        
+    output_file: string
+        If None (default), output file (recovery_outputs.json) will be saved. If string, name the 
+        output file as specified.
     
     seed: int
         Random seed to be passed to the Numpy random engine. Default behavior
@@ -190,8 +196,11 @@ def run_analysis(input_dir, output_dir, seed=None, force_rebuild=False):
                                             fnc_keys_6 = list(functionality[k_1][k_2][k_3][k_4][k_5].keys())
     
     output_json_object = json.dumps(functionality)
+
+    if output_file is None:
+        output_file = "recovery_outputs.json"
     
-    with open(os.path.join(output_dir, "recovery_outputs.json"), "w") as outfile:
+    with open(os.path.join(output_dir, output_file), "w") as outfile:
         outfile.write(output_json_object)
     
     end_time = time.time()

--- a/src/atc138/functionality/other_functionality_functions.py
+++ b/src/atc138/functionality/other_functionality_functions.py
@@ -103,7 +103,7 @@ def fn_building_safety(damage, building_model, damage_consequences, utilities,
             recovery_day['fire_suppression'] = np.fmax(recovery_day['fire_suppression'], np.amax(repair_complete_day[:,damage['fnc_filters']['fire_building']], axis=1))
     
             # Consider utilities (assume no backup water supply)
-            recovery_day['fire_suppression'] = np.fmax(recovery_day['building']['fire'], np.array(utilities['water'])) # Assumes building does not have backup water supply
+            recovery_day['fire_suppression'] = np.fmax(recovery_day['fire_suppression'], np.array(utilities['water'])) # Assumes building does not have backup water supply
         
             # Componet Breakdowns
             comp_breakdowns['fire_suppression'][:,:,tu] = damage['fnc_filters']['fire_building'] * repair_complete_day
@@ -297,7 +297,7 @@ def fn_building_safety(damage, building_model, damage_consequences, utilities,
                     # Add days to components that are affecting occupancy
                     contributing_drops = ((damaged_comps * filt_fs_drop) > 0)  * np.logical_not(fire_drop_operational).reshape(num_reals,1) #count all components that contributed to non operational fire drops
                     contributing_branches = ((damaged_comps * filt_fs_drop) > 0)  * np.logical_not(fire_branch_operational).reshape(num_reals,1) # count all components that contributed to non operational fire drops
-                    contributing_comps = np.amax(contributing_drops, contributing_branches)
+                    contributing_comps = np.fmax(contributing_drops, contributing_branches)
                     comp_breakdowns_local_fire[:,:,tu] = comp_breakdowns_local_fire[:,:,tu] + contributing_comps * delta_day.reshape(num_reals,1)
     
                     # Change the comps for the next increment


### PR DESCRIPTION
## Summary

This PR fixes an error that exists when examples are ran with `fire_watch=False`. This raises a call in `other_functionality_functions.py` where an undefined key in the `recovery_day` dictionary was referenced.

Additionally, this PR allows for an optional filename to be passed to `run_analysis`. This allows users to output results in alternate names other than `recovery_outputs.json`, as is often the case when batch running multiple iterations of the same input.

## Changes:

- Fixed key reference for `fire_suppression` in `recovery_day` of `other_functionality_functions.py`. The previous key `recovery_day['building']['fire']` did not exist.
- `driver` and `cli` now support an optional argument `output_file`, defaulting to `recovery_outputs.json`
